### PR TITLE
Bypass Keycloak AuthInterceptor when requesting local templates

### DIFF
--- a/plugins/keycloak/ts/keycloakPlugin.ts
+++ b/plugins/keycloak/ts/keycloakPlugin.ts
@@ -98,6 +98,10 @@ module HawtioKeycloak {
     }
 
     request = (request) => {
+      // bypass for local templates
+      if (request.url.indexOf('http') !== 0) {
+        return request;
+      }
       var addBearer, deferred;
       addBearer = () => {
         var keycloak = HawtioKeycloak.keycloak;


### PR DESCRIPTION
When using templateUrl in a directive, the fact that local templates go through Keycloak AuthInterceptor makes the content of the directive "flash" when something, eg: updating URL params, causes a routeChange. The same won't happen if using template directly instead of templateUrl.

The problem also shows when using ng-include, with no easy workaround.

This fixes it by only applying the interceptor for external resources.

This is related to https://issues.jboss.org/browse/HAWKULAR-984