### PR TITLE
Assign AuthInterceptorService.$inject to AuthInterceptorService.Factory.$inject

### DIFF
--- a/plugins/keycloak/ts/keycloakPlugin.ts
+++ b/plugins/keycloak/ts/keycloakPlugin.ts
@@ -136,6 +136,7 @@ module HawtioKeycloak {
       return this.$q.reject(rejection);
     };
   }
+  AuthInterceptorService.Factory.$inject = AuthInterceptorService.$inject;
 
   _module.requires.push("ngIdle");
 }


### PR DESCRIPTION
Fix `[$injector:unpr] Unknown provider: eProvider <- e <- $http <- $templateRequest <- $route` error in web browser when using Keycloak as OAuth provider.