### PR TITLE
chore : added gh action stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,29 @@
+name: "Stale"
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-stale: 365
+        days-before-close: 14
+        stale-issue-label: status/stale
+        exempt-issue-labels: status/never-stale
+        stale-issue-message: |
+          This issue has been automatically marked as stale due to a year of inactivity.
+          It will be closed if no further activity occurs within 14 days.
+          If you think that’s incorrect or the issue should never stale, please simply write any comment.
+          Thanks for your contributions!
+        stale-pr-label: status/stale
+        exempt-pr-labels: status/never-stale
+        stale-pr-message: |
+          This PR has been automatically marked as stale due to a year of inactivity.
+          It will be closed if no further activity occurs within 14 days.
+          If you think that’s incorrect or the issue should never stale, please simply write any comment.
+          Thanks for your contributions!


### PR DESCRIPTION
Added a github action stale which adds tags to the PR's and issues with over a year of inactivity. They are automatically closed after 14 days of adding the stale tag. The entire repository gets checked at 12:00 AM GMT.