### PR TITLE
[CVE-2022-0613][CVE-2022-24723] Upgrade urijs to 1.19.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "lodash.templatesettings": "4.1.0",
     "through2": "2.0.3",
     "@types/marked": "0.3.0",
-    "urijs": "1.19.0",
+    "urijs": "1.19.9",
     "@types/jasmine": "2.8.5",
     "@types/lodash": "4.14.93",
     "patternfly": "3.32.1",


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2022-0613
https://nvd.nist.gov/vuln/detail/CVE-2022-24723