### PR TITLE
feat: support PKCE in keycloak plugin (#29)

### DIFF
--- a/plugins/keycloak/keycloak.globals.ts
+++ b/plugins/keycloak/keycloak.globals.ts
@@ -13,6 +13,13 @@ namespace HawtioKeycloak {
      * Default: true
      */
     jaas?: boolean;
+
+    /**
+     * The method for Proof Key Code Exchange (PKCE) to use.
+     * Configuring this value enables the PKCE mechanism. Available options:
+     * - "S256" - The SHA256 based PKCE method
+     */
+    pkceMethod?: string; 
   };
 
   export const pluginName: string = 'hawtio-oauth-keycloak';

--- a/plugins/keycloak/keycloak.module.ts
+++ b/plugins/keycloak/keycloak.module.ts
@@ -110,7 +110,12 @@ namespace HawtioKeycloak {
 
   function initKeycloak(callback: () => void): void {
     keycloak = Keycloak(config);
-    keycloak.init({ onLoad: 'login-required' })
+    let initOptions : Keycloak.KeycloakInitOptions = { onLoad: 'login-required' };
+    if(config.pkceMethod) {
+      log.debug("Using pkceMethod: ", config.pkceMethod);
+      initOptions.pkceMethod = config.pkceMethod; 
+    }
+    keycloak.init(initOptions)
       .success((authenticated) => {
         log.debug("Authenticated:", authenticated);
         if (!authenticated) {

--- a/test-plugins/example/example.module.ts
+++ b/test-plugins/example/example.module.ts
@@ -68,7 +68,8 @@ namespace Example {
       HawtioKeycloak.config = {
         clientId: 'hawtio-client',
         url: 'http://localhost:8080/auth',
-        realm: 'hawtio-demo'
+        realm: 'hawtio-demo',
+        pkceMethod: 'S256'
       };
       next();
     }

--- a/test-plugins/hawtio-demo-realm.json
+++ b/test-plugins/hawtio-demo-realm.json
@@ -22,7 +22,10 @@
       ],
       "webOrigins" : [ "+" ],
       "bearerOnly" : false,
-      "publicClient" : true
+      "publicClient" : true,
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      }
     }
   ],
   "users" : [ {

--- a/vendor/keycloak-js/keycloak.d.ts
+++ b/vendor/keycloak-js/keycloak.d.ts
@@ -94,6 +94,13 @@ declare namespace Keycloak {
 		 * @default standard
 		 */
 		flow?: KeycloakFlow;
+
+		/**
+		 * The method for Proof Key Code Exchange (PKCE) to use.
+		 * Configuring this value enables the PKCE mechanism. Available options:
+		 * - "S256" - The SHA256 based PKCE method
+		 */
+		pkceMethod?: string; 
 	}
 
 	interface KeycloakLoginOptions {


### PR DESCRIPTION
Adds support for Proof Key Code Exchange (PKCE) for the keycloak
plugin by adding a new config option.

Resolves #29 